### PR TITLE
Enable `leftpad` option for encoding

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -176,12 +176,12 @@ func structSetter(v reflect.Value, raw []byte) error {
 			continue
 		}
 		sf := t.Field(i)
-		startPos, endPos, ok := parseTag(sf.Tag.Get("fixed"))
-		if !ok {
-			continue
+		spec, err := parseTag(sf.Tag.Get("fixed"))
+		if err != nil {
+			return err
 		}
-		rawValue := rawValueFromLine(raw, startPos, endPos)
-		err := newValueSetter(sf.Type)(fv, rawValue)
+		rawValue := rawValueFromLine(raw, spec.startPos, spec.endPos)
+		err = newValueSetter(sf.Type)(fv, rawValue)
 		if err != nil {
 			return &UnmarshalTypeError{string(rawValue), sf.Type, t.Name(), sf.Name, err}
 		}

--- a/encode.go
+++ b/encode.go
@@ -154,10 +154,9 @@ func structEncoder(v reflect.Value) ([]byte, error) {
 		var (
 			err  error
 			spec fieldSpec
-			ok   bool
 		)
-		spec.startPos, spec.endPos, ok = parseTag(f.Tag.Get("fixed"))
-		if !ok {
+		spec, err = parseTag(f.Tag.Get("fixed"))
+		if err != nil {
 			continue
 		}
 		spec.value, err = newValueEncoder(f.Type)(v.Field(i))
@@ -171,6 +170,7 @@ func structEncoder(v reflect.Value) ([]byte, error) {
 
 type fieldSpec struct {
 	startPos, endPos int
+	leftpad          bool
 	value            []byte
 }
 

--- a/tags_test.go
+++ b/tags_test.go
@@ -10,33 +10,38 @@ func TestParseTag(t *testing.T) {
 		tag      string
 		startPos int
 		endPos   int
+		leftpad  bool
 		ok       bool
 	}{
-		{"Valid Tag", "0,10", 0, 10, true},
-		{"Valid Tag Single position", "5,5", 5, 5, true},
-		{"Tag Empty", "", 0, 0, false},
-		{"Tag Too short", "0", 0, 0, false},
-		{"Tag Too Long", "2,10,11", 0, 0, false},
-		{"StartPos Not Integer", "hello,3", 0, 0, false},
-		{"EndPos Not Integer", "3,hello", 0, 0, false},
-		{"Tag Contains a Space", "4, 11", 0, 0, false},
-		{"Tag Interval Invalid", "14,5", 0, 0, false},
-		{"Tag Both Positions Zero", "0,0", 0, 0, false},
+		{"Valid Tag", "0,10", 0, 10, false, true},
+		{"Valid Tag Single position", "5,5", 5, 5, false, true},
+		{"Tag Empty", "", 0, 0, false, false},
+		{"Tag Too short", "0", 0, 0, false, false},
+		{"Tag Too Long", "2,10,11", 0, 0, false, false},
+		{"StartPos Not Integer", "hello,3", 0, 0, false, false},
+		{"EndPos Not Integer", "3,hello", 0, 0, false, false},
+		{"Tag Contains a Space", "4, 11", 0, 0, false, false},
+		{"Tag Interval Invalid", "14,5", 0, 0, false, false},
+		{"Tag Both Positions Zero", "0,0", 0, 0, false, false},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			startPos, endPos, ok := parseTag(tt.tag)
-			if tt.ok != ok {
-				t.Errorf("parseTag() ok want %v, have %v", tt.ok, ok)
+			spec, err := parseTag(tt.tag)
+			if tt.ok != (err == nil) {
+				t.Errorf("parseTag() shouldError %v, have %v", !tt.ok, err)
 			}
 
 			// only check startPos and endPos if valid tags are expected
 			if tt.ok {
-				if tt.startPos != startPos {
-					t.Errorf("parseTag() startPos want %v, have %v", tt.startPos, startPos)
+				if tt.startPos != spec.startPos {
+					t.Errorf("parseTag() startPos want %v, have %v", tt.startPos, spec.startPos)
 				}
 
-				if tt.endPos != endPos {
-					t.Errorf("parseTag() endPos want %v, have %v", tt.endPos, endPos)
+				if tt.endPos != spec.endPos {
+					t.Errorf("parseTag() endPos want %v, have %v", tt.endPos, spec.endPos)
+				}
+
+				if tt.leftpad != spec.leftpad {
+					t.Errorf("parseTag() lefpad expected %v, have %v", tt.leftpad, spec.leftpad)
 				}
 			}
 		})


### PR DESCRIPTION
In some formats values would be expected to be padded in the left.

e.g:
```go
type DifferentFixedTags struct {
	RegularStr string `fixed:"1,5"`
	RegularInt int    `fixed:"6,10"`

 	PadStr string `fixed:"11,15,leftpad"`
	PadInt int    `fixed:"16,20,leftpad"`
}
d := DifferentFixedTags{"one", 1, "two", 2}
fixedwidth.Marshal(d)
// Result: "one  1      two00002"
```