### PR TITLE
Fixes #6 -- expose if an EOF happens in Decoder.Decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,5 +63,22 @@ fmt.Printf("%+v\n", people[2])
 //{ID:3 FirstName:Jane LastName:Doe Grade:79.5}
 ```
 
+It is also possible to read data incrementally
+
+```go
+decoder := fixedwidth.NewDecoder(bytes.NewReader(data))
+for {
+    var element myStruct
+    err := decoder.Decode(&element)
+    if err == io.EOF {
+        break
+    }
+    if err != nil {
+        log.Fatal(err)
+    }
+    handle(element)
+}
+```
+
 ## Licence
 MIT

--- a/decode.go
+++ b/decode.go
@@ -91,6 +91,9 @@ func (d *Decoder) Decode(v interface{}) error {
 
 	err, ok := d.readLine(reflect.ValueOf(v))
 	if d.done && err == nil && !ok {
+		// d.done means we've reached the end of the file. err == nil && !ok
+		// indicates that there was no data to read, so we propagate an io.EOF
+		// upwards so our caller knows there is no data left.
 		return io.EOF
 	}
 	return err

--- a/decode.go
+++ b/decode.go
@@ -74,7 +74,8 @@ func (e *UnmarshalTypeError) Error() string {
 // pointed to by v.
 //
 // In the case that v points to a struct value, Decode will read a
-// single line from the input.
+// single line from the input. If there is no data remaining in the file,
+// returns io.EOF
 //
 // In the case that v points to a slice value, Decode will read until
 // the end of its input.
@@ -88,7 +89,10 @@ func (d *Decoder) Decode(v interface{}) error {
 		return d.readLines(reflect.ValueOf(v).Elem())
 	}
 
-	err, _ := d.readLine(reflect.ValueOf(v))
+	err, ok := d.readLine(reflect.ValueOf(v))
+	if d.done && err == nil && !ok {
+		return io.EOF
+	}
 	return err
 }
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -151,8 +151,6 @@ func TestUnmarshal(t *testing.T) {
 			{"Invalid Unmarshal Not Pointer 1", struct{}{}, true},
 			{"Invalid Unmarshal Not Pointer 2", []struct{}{}, true},
 			{"Valid Unmarshal slice", &[]struct{}{}, false},
-			// TODO: technically you can unmarshal an empty struct from empty
-			// string, since it takes no space. Should that EOF or succeed?
 			{"Valid Unmarshal struct", &struct{}{}, true},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
@@ -224,7 +222,9 @@ func TestNewValueSetter(t *testing.T) {
 	}
 }
 
-func TestDecode(t *testing.T) {
+// Verify the behavior of Decoder.Decode at the end of a file. See
+// https://github.com/ianlopshire/go-fixedwidth/issues/6 for more details.
+func TestDecode_EOF(t *testing.T) {
 	d := NewDecoder(bytes.NewReader([]byte("")))
 	type S struct {
 		Field1 string `fixed:"1,1"`


### PR DESCRIPTION
You'll see that there were two tests I needed to change. The first change I think is definitely right -- you can't read a struct with fields from empty data. The second one I'm less confident in (see the TODO comment I left), I'd appreciate your feedback on that.