### PR TITLE
Encoding Performance Improvements

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,172 @@
+package fixedwidth
+
+import (
+	"bytes"
+	"testing"
+)
+
+type mixedData struct {
+	F1  string   `fixed:"1,10"`
+	F2  *string  `fixed:"11,20"`
+	F3  int64    `fixed:"21,30"`
+	F4  *int64   `fixed:"31,40"`
+	F5  int32    `fixed:"41,50"`
+	F6  *int32   `fixed:"51,60"`
+	F7  int16    `fixed:"61,70"`
+	F8  *int16   `fixed:"71,80"`
+	F9  int8     `fixed:"81,90"`
+	F10 *int8    `fixed:"91,100"`
+	F11 float64  `fixed:"101,110"`
+	F12 *float64 `fixed:"111,120"`
+	F13 float32  `fixed:"121,130"`
+	//F14 *float32 `fixed:"131,140"`
+}
+
+var mixedDataInstance = mixedData{"foo", stringp("foo"), 42, int64p(42), 42, int32p(42), 42, int16p(42), 42, int8p(42), 4.2, float64p(4.2), 4.2} //,float32p(4.2)}
+
+func BenchmarkUnmarshal_MixedData_1(b *testing.B) {
+	data := []byte(`       foo       foo        42        42        42        42        42        42        42        42       4.2       4.2       4.2       4.2`)
+	var v mixedData
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = Unmarshal(data, &v)
+	}
+}
+
+func BenchmarkUnmarshal_MixedData_1000(b *testing.B) {
+	data := bytes.Repeat([]byte(`       foo       foo        42        42        42        42        42        42        42        42       4.2       4.2       4.2       4.2`+"\n"), 100)
+	var v []mixedData
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = Unmarshal(data, &v)
+	}
+}
+
+func BenchmarkUnmarshal_MixedData_100000(b *testing.B) {
+	data := bytes.Repeat([]byte(`       foo       foo        42        42        42        42        42        42        42        42       4.2       4.2       4.2       4.2`+"\n"), 10000)
+	var v []mixedData
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = Unmarshal(data, &v)
+	}
+}
+
+func BenchmarkUnmarshal_String(b *testing.B) {
+	data := []byte(`foo       `)
+	var v struct {
+		F1 string `fixed:"1,10"`
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = Unmarshal(data, &v)
+	}
+}
+
+func BenchmarkUnmarshal_StringPtr(b *testing.B) {
+	data := []byte(`foo       `)
+	var v struct {
+		F1 *string `fixed:"1,10"`
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = Unmarshal(data, &v)
+	}
+}
+
+func BenchmarkUnmarshal_Int64(b *testing.B) {
+	data := []byte(`42       `)
+	var v struct {
+		F1 int64 `fixed:"1,10"`
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = Unmarshal(data, &v)
+	}
+}
+
+func BenchmarkUnmarshal_Float64(b *testing.B) {
+	data := []byte(`4.2      `)
+	var v struct {
+		F1 float64 `fixed:"1,10"`
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = Unmarshal(data, &v)
+	}
+}
+
+func BenchmarkMarshal_MixedData_1(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Marshal(mixedDataInstance)
+	}
+}
+
+func BenchmarkMarshal_MixedData_1000(b *testing.B) {
+	v := make([]mixedData, 1000)
+	for i := range v {
+		v[i] = mixedDataInstance
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Marshal(v)
+	}
+}
+
+func BenchmarkMarshal_MixedData_100000(b *testing.B) {
+	v := make([]mixedData, 100000)
+	for i := range v {
+		v[i] = mixedDataInstance
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Marshal(v)
+	}
+}
+
+func BenchmarkMarshal_String(b *testing.B) {
+	v := struct {
+		F1 string `fixed:"1,10"`
+	}{
+		F1: "foo",
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Marshal(v)
+	}
+}
+
+func BenchmarkMarshal_StringPtr(b *testing.B) {
+	v := struct {
+		F1 *string `fixed:"1,10"`
+	}{
+		F1: stringp("foo"),
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Marshal(v)
+	}
+}
+
+func BenchmarkMarshal_Int64(b *testing.B) {
+	v := struct {
+		F1 int64 `fixed:"1,10"`
+	}{
+		F1: 42,
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Marshal(v)
+	}
+}
+
+func BenchmarkMarshal_Float64(b *testing.B) {
+	v := struct {
+		F1 float64 `fixed:"1,10"`
+	}{
+		F1: 4.2,
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Marshal(v)
+	}
+}

--- a/fixedwidth_test.go
+++ b/fixedwidth_test.go
@@ -10,6 +10,10 @@ var (
 func float64p(v float64) *float64 { return &v }
 func float32p(v float32) *float32 { return &v }
 func intp(v int) *int             { return &v }
+func int64p(v int64) *int64       { return &v }
+func int32p(v int32) *int32       { return &v }
+func int16p(v int16) *int16       { return &v }
+func int8p(v int8) *int8          { return &v }
 func stringp(v string) *string    { return &v }
 
 // EncodableString is a string that implements the encoding TextUnmarshaler and TextMarshaler interface.


### PR DESCRIPTION
Refactored the struct encoder to reduce allocations and improve performance.

## Benchmarks

```
benchmark                                 old ns/op     new ns/op     delta
BenchmarkUnmarshal_MixedData_1-8          6674          6571          -1.54%
BenchmarkUnmarshal_MixedData_1000-8       764907        750495        -1.88%
BenchmarkUnmarshal_MixedData_100000-8     72274997      72978644      +0.97%
BenchmarkUnmarshal_String-8               1315          1382          +5.10%
BenchmarkUnmarshal_StringPtr-8            1666          1421          -14.71%
BenchmarkUnmarshal_Int64-8                1316          1314          -0.15%
BenchmarkUnmarshal_Float64-8              1354          1350          -0.30%
BenchmarkMarshal_MixedData_1-8            7854          3831          -51.22%
BenchmarkMarshal_MixedData_1000-8         6709016       3123703       -53.44%
BenchmarkMarshal_MixedData_100000-8       716520082     325317108     -54.60%
BenchmarkMarshal_String-8                 1282          1023          -20.20%
BenchmarkMarshal_StringPtr-8              1309          1035          -20.93%
BenchmarkMarshal_Int64-8                  1274          969           -23.94%
BenchmarkMarshal_Float64-8                1622          1326          -18.25%

benchmark                                 old allocs     new allocs     delta
BenchmarkUnmarshal_MixedData_1-8          53             53             +0.00%
BenchmarkUnmarshal_MixedData_1000-8       5704           5704           +0.00%
BenchmarkUnmarshal_MixedData_100000-8     570005         570005         +0.00%
BenchmarkUnmarshal_String-8               8              8              +0.00%
BenchmarkUnmarshal_StringPtr-8            9              9              +0.00%
BenchmarkUnmarshal_Int64-8                8              8              +0.00%
BenchmarkUnmarshal_Float64-8              9              9              +0.00%
BenchmarkMarshal_MixedData_1-8            79             48             -39.24%
BenchmarkMarshal_MixedData_1000-8         75009          44009          -41.33%
BenchmarkMarshal_MixedData_100000-8       7500015        4400015        -41.33%
BenchmarkMarshal_String-8                 12             9              -25.00%
BenchmarkMarshal_StringPtr-8              12             9              -25.00%
BenchmarkMarshal_Int64-8                  12             9              -25.00%
BenchmarkMarshal_Float64-8                15             12             -20.00%

benchmark                                 old bytes     new bytes     delta
BenchmarkUnmarshal_MixedData_1-8          5280          5280          +0.00%
BenchmarkUnmarshal_MixedData_1000-8       183316        183316        +0.00%
BenchmarkUnmarshal_MixedData_100000-8     17900777      17900778      +0.00%
BenchmarkUnmarshal_String-8               4336          4336          +0.00%
BenchmarkUnmarshal_StringPtr-8            4368          4368          +0.00%
BenchmarkUnmarshal_Int64-8                4336          4336          +0.00%
BenchmarkUnmarshal_Float64-8              4352          4352          +0.00%
BenchmarkMarshal_MixedData_1-8            7016          5248          -25.20%
BenchmarkMarshal_MixedData_1000-8         3068046       1300043       -57.63%
BenchmarkMarshal_MixedData_100000-8       289538328     112738582     -61.06%
BenchmarkMarshal_String-8                 4432          4344          -1.99%
BenchmarkMarshal_StringPtr-8              4432          4344          -1.99%
BenchmarkMarshal_Int64-8                  4424          4336          -1.99%
BenchmarkMarshal_Float64-8                4496          4400          -2.14%
```