### PR TITLE
Support marshal unicode

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -23,6 +23,7 @@ type mixedData struct {
 }
 
 var mixedDataInstance = mixedData{"foo", stringp("foo"), 42, int64p(42), 42, int32p(42), 42, int16p(42), 42, int8p(42), 4.2, float64p(4.2), 4.2} //,float32p(4.2)}
+var mixedDataWithUnicodeInstance = mixedData{"f☃☃", stringp("f☃☃"), 42, int64p(42), 42, int32p(42), 42, int16p(42), 42, int8p(42), 4.2, float64p(4.2), 4.2}
 
 func BenchmarkUnmarshal_MixedData_1(b *testing.B) {
 	data := []byte(`       foo       foo        42        42        42        42        42        42        42        42       4.2       4.2       4.2       4.2`)
@@ -140,6 +141,37 @@ func BenchmarkMarshal_MixedData_100000(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Marshal(v)
+	}
+}
+
+func BenchmarkEncode_Codepoint_MixedData_1(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		e := NewEncoder(&bytes.Buffer{})
+		e.Encode(mixedDataWithUnicodeInstance)
+	}
+}
+
+func BenchmarkEncode_Codepoint_MixedData_1000(b *testing.B) {
+	v := make([]mixedData, 1000)
+	for i := range v {
+		v[i] = mixedDataWithUnicodeInstance
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		e := NewEncoder(&bytes.Buffer{})
+		e.Encode(v)
+	}
+}
+
+func BenchmarkEncode_Codepoint_MixedData_100000(b *testing.B) {
+	v := make([]mixedData, 100000)
+	for i := range v {
+		v[i] = mixedDataWithUnicodeInstance
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		e := NewEncoder(&bytes.Buffer{})
+		e.Encode(v)
 	}
 }
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -48,7 +48,9 @@ func TestMarshal(t *testing.T) {
 		shouldErr bool
 	}{
 		{"single line", H{"foo", 1}, []byte("foo  1    "), false},
+		{"single line - unicode", H{"fôô", 1}, []byte("fôô  1    "), false},
 		{"multiple line", []H{{"foo", 1}, {"bar", 2}}, []byte("foo  1    \nbar  2    "), false},
+		{"multiple line - unicode", []H{{"fôô", 1}, {"bâr", 2}}, []byte("fôô  1    \nbâr  2    "), false},
 		{"empty slice", []H{}, nil, false},
 		{"pointer", &H{"foo", 1}, []byte("foo  1    "), false},
 		{"nil", nil, nil, false},


### PR DESCRIPTION
Hi @ianlopshire, I make a pull request for supporting marshal Unicode.
Here is the benchmark:

```
benchmark                               old ns/op     new ns/op     delta
BenchmarkMarshal_MixedData_1-4          4135          3843          -7.06%
BenchmarkMarshal_MixedData_1000-4       3827841       3563933       -6.89%
BenchmarkMarshal_MixedData_100000-4     336806933     373349191     +10.85%
BenchmarkMarshal_String-4               1308          1069          -18.27%
BenchmarkMarshal_StringPtr-4            1266          1154          -8.85%
BenchmarkMarshal_Int64-4                1038          1059          +2.02%
BenchmarkMarshal_Float64-4              1381          1406          +1.81%

benchmark                               old allocs     new allocs     delta
BenchmarkMarshal_MixedData_1-4          48             48             +0.00%
BenchmarkMarshal_MixedData_1000-4       44009          44009          +0.00%
BenchmarkMarshal_MixedData_100000-4     4400015        4400015        +0.00%
BenchmarkMarshal_String-4               9              9              +0.00%
BenchmarkMarshal_StringPtr-4            9              9              +0.00%
BenchmarkMarshal_Int64-4                9              9              +0.00%
BenchmarkMarshal_Float64-4              12             12             +0.00%

benchmark                               old bytes     new bytes     delta
BenchmarkMarshal_MixedData_1-4          5248          5680          +8.23%
BenchmarkMarshal_MixedData_1000-4       1300042       1732044       +33.23%
BenchmarkMarshal_MixedData_100000-4     112738222     155938227     +38.32%
BenchmarkMarshal_String-4               4344          4376          +0.74%
BenchmarkMarshal_StringPtr-4            4344          4376          +0.74%
BenchmarkMarshal_Int64-4                4336          4368          +0.74%
BenchmarkMarshal_Float64-4              4400          4440          +0.91%
```

Please let me know if I missed any case or something that can be improved.

Regards,
Huy Dang