### PR TITLE
Cache field encoders and setter

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -257,10 +257,10 @@ func structSetter(v reflect.Value, raw rawValue) error {
 		if !fieldSpec.ok {
 			continue
 		}
-		sf := t.Field(i)
 		rawValue := rawValueFromLine(raw, fieldSpec.startPos, fieldSpec.endPos)
-		err := newValueSetter(sf.Type)(v.Field(i), rawValue)
+		err := fieldSpec.setter(v.Field(i), rawValue)
 		if err != nil {
+			sf := t.Field(i)
 			return &UnmarshalTypeError{string(rawValue.bytes), sf.Type, t.Name(), sf.Name, err}
 		}
 	}

--- a/encode.go
+++ b/encode.go
@@ -156,7 +156,7 @@ func structEncoder(v reflect.Value) ([]byte, error) {
 			continue
 		}
 
-		val, err := newValueEncoder(v.Field(i).Type())(v.Field(i))
+		val, err := spec.encoder(v.Field(i))
 		if err != nil {
 			return nil, err
 		}

--- a/tags.go
+++ b/tags.go
@@ -37,6 +37,8 @@ type structSpec struct {
 
 type fieldSpec struct {
 	startPos, endPos int
+	encoder          valueEncoder
+	setter           valueSetter
 	ok               bool
 }
 
@@ -50,6 +52,8 @@ func buildStructSpec(t reflect.Type) structSpec {
 		if ss.fieldSpecs[i].endPos > ss.ll {
 			ss.ll = ss.fieldSpecs[i].endPos
 		}
+		ss.fieldSpecs[i].encoder = newValueEncoder(f.Type)
+		ss.fieldSpecs[i].setter = newValueSetter(f.Type)
 	}
 	return ss
 }


### PR DESCRIPTION
Before:

```
alex@penguin ~/p/go-fixedwidth> go test -bench='BenchmarkUnmarshal_MixedData_1000'
goos: linux
goarch: amd64
pkg: github.com/ianlopshire/go-fixedwidth
BenchmarkUnmarshal_MixedData_1000-4     	    2000	    731466 ns/op
BenchmarkUnmarshal_MixedData_100000-4   	      20	  68835818 ns/op
PASS
ok  	github.com/ianlopshire/go-fixedwidth	3.070s
alex@penguin ~/p/go-fixedwidth> go test -bench='BenchmarkUnmarshal_MixedData_1000'
goos: linux
goarch: amd64
pkg: github.com/ianlopshire/go-fixedwidth
BenchmarkUnmarshal_MixedData_1000-4     	    2000	    728904 ns/op
BenchmarkUnmarshal_MixedData_100000-4   	      20	  68418671 ns/op
PASS
ok  	github.com/ianlopshire/go-fixedwidth	3.047s
```

After:

```
alex@penguin ~/p/go-fixedwidth> go test -bench='BenchmarkUnmarshal_MixedData_1000'
goos: linux
goarch: amd64
pkg: github.com/ianlopshire/go-fixedwidth
BenchmarkUnmarshal_MixedData_1000-4     	    2000	    515373 ns/op
BenchmarkUnmarshal_MixedData_100000-4   	      20	  55145695 ns/op
PASS
ok  	github.com/ianlopshire/go-fixedwidth	2.292s
alex@penguin ~/p/go-fixedwidth> go test -bench='BenchmarkUnmarshal_MixedData_1000'
goos: linux
goarch: amd64
pkg: github.com/ianlopshire/go-fixedwidth
BenchmarkUnmarshal_MixedData_1000-4     	    2000	    536994 ns/op
BenchmarkUnmarshal_MixedData_100000-4   	      20	  52838184 ns/op
PASS
ok  	github.com/ianlopshire/go-fixedwidth	2.287s
```