### PR TITLE
Optimize ptrSetter

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -294,6 +294,7 @@ func interfaceSetter(v reflect.Value, raw rawValue) error {
 }
 
 func ptrSetter(t reflect.Type) valueSetter {
+	innerSetter := newValueSetter(t.Elem())
 	return func(v reflect.Value, raw rawValue) error {
 		if len(raw.bytes) <= 0 {
 			return nilSetter(v, raw)
@@ -301,7 +302,7 @@ func ptrSetter(t reflect.Type) valueSetter {
 		if v.IsNil() {
 			v.Set(reflect.New(t.Elem()))
 		}
-		return newValueSetter(v.Elem().Type())(reflect.Indirect(v), raw)
+		return innerSetter(reflect.Indirect(v), raw)
 	}
 }
 


### PR DESCRIPTION
Before:

```
alex@penguin ~/p/go-fixedwidth> go test -bench='BenchmarkUnmarshal_MixedData_1000'
goos: linux
goarch: amd64
pkg: github.com/ianlopshire/go-fixedwidth
BenchmarkUnmarshal_MixedData_1000-4     	    5000	    390835 ns/op
BenchmarkUnmarshal_MixedData_100000-4   	      50	  33693614 ns/op
PASS
ok  	github.com/ianlopshire/go-fixedwidth	3.740s
alex@penguin ~/p/go-fixedwidth> go test -bench='BenchmarkUnmarshal_MixedData_1000'
goos: linux
goarch: amd64
pkg: github.com/ianlopshire/go-fixedwidth
BenchmarkUnmarshal_MixedData_1000-4     	    5000	    399255 ns/op
BenchmarkUnmarshal_MixedData_100000-4   	      50	  35145768 ns/op
PASS
ok  	github.com/ianlopshire/go-fixedwidth	3.857s
```

After:

```
alex@penguin ~/p/go-fixedwidth> go test -bench='BenchmarkUnmarshal_MixedData_1000'
goos: linux
goarch: amd64
pkg: github.com/ianlopshire/go-fixedwidth
BenchmarkUnmarshal_MixedData_1000-4     	    5000	    327261 ns/op
BenchmarkUnmarshal_MixedData_100000-4   	      50	  30777707 ns/op
PASS
ok  	github.com/ianlopshire/go-fixedwidth	3.272s
alex@penguin ~/p/go-fixedwidth> go test -bench='BenchmarkUnmarshal_MixedData_1000'
goos: linux
goarch: amd64
pkg: github.com/ianlopshire/go-fixedwidth
BenchmarkUnmarshal_MixedData_1000-4     	    5000	    348843 ns/op
BenchmarkUnmarshal_MixedData_100000-4   	      50	  31734454 ns/op
PASS
ok  	github.com/ianlopshire/go-fixedwidth	3.431s
```