### PR TITLE
Simplify checking if a value is a slice in Decoder.Decode

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -94,7 +94,7 @@ func (d *Decoder) Decode(v interface{}) error {
 		return &InvalidUnmarshalError{reflect.TypeOf(v)}
 	}
 
-	if reflect.Indirect(reflect.ValueOf(v)).Kind() == reflect.Slice {
+	if rv.Elem().Kind() == reflect.Slice {
 		return d.readLines(reflect.ValueOf(v).Elem())
 	}
 


### PR DESCRIPTION
This nominally removes a small handful of instructions, but I doubt it's measurable. `reflect.Indirect` just calls `Elem()` if `rv.Kind() == reflect.Ptr`, which we already know it is.