### PR TITLE
Store rawValue as a string instead of []bytes

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -211,7 +211,7 @@ func TestNewValueSetter(t *testing.T) {
 			// ensure we have an addressable target
 			var i = reflect.Indirect(reflect.New(reflect.TypeOf(tt.expected)))
 
-			err := newValueSetter(i.Type())(i, rawValue{bytes: tt.raw})
+			err := newValueSetter(i.Type())(i, rawValue{data: string(tt.raw)})
 			if tt.shouldErr != (err != nil) {
 				t.Errorf("newValueSetter(%s)() err want %v, have %v (%v)", reflect.TypeOf(tt.expected).Name(), tt.shouldErr, err != nil, err.Error())
 			}
@@ -323,7 +323,7 @@ func TestNewRawValue(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := newRawValue(tt.input, true)
+			result, err := newRawValue(string(tt.input), true)
 			if err != nil {
 				t.Errorf("newRawValue(%v, true): Unexpected error", tt.input)
 			} else if !reflect.DeepEqual(tt.expected, result.codepointIndices) {


### PR DESCRIPTION
This means when decoding to a bunch of strings in a struct, they are all just sub-slices of one string, instead of needing to be copies. This also helps integer and float deserialization. It may pessimize the use of TextDecoder though.

Seems to be about a 10-20% win in decode time, and a reduction in allocations by 50%

Before:

```
alex@penguin ~/p/go-fixedwidth> go test -bench=BenchmarkUnmarshal_MixedData_100000 
goos: linux
goarch: amd64
pkg: github.com/ianlopshire/go-fixedwidth
BenchmarkUnmarshal_MixedData_100000-4   	      32	  38323159 ns/op	 9603155 B/op	  220005 allocs/op
PASS
ok  	github.com/ianlopshire/go-fixedwidth	1.301s
alex@penguin ~/p/go-fixedwidth> go test -bench=BenchmarkUnmarshal_MixedData_100000 
goos: linux
goarch: amd64
pkg: github.com/ianlopshire/go-fixedwidth
BenchmarkUnmarshal_MixedData_100000-4   	      34	  35114857 ns/op	10649528 B/op	  220005 allocs/op
PASS
ok  	github.com/ianlopshire/go-fixedwidth	2.228s
alex@penguin ~/p/go-fixedwidth> go test -bench=BenchmarkUnmarshal_MixedData_100000 
goos: linux
goarch: amd64
pkg: github.com/ianlopshire/go-fixedwidth
BenchmarkUnmarshal_MixedData_100000-4   	      36	  32726607 ns/op	10262592 B/op	  220005 allocs/op
PASS
ok  	github.com/ianlopshire/go-fixedwidth	1.278s
```

After:

```
alex@penguin ~/p/go-fixedwidth> go test -bench=BenchmarkUnmarshal_MixedData_100000 
goos: linux
goarch: amd64
pkg: github.com/ianlopshire/go-fixedwidth
BenchmarkUnmarshal_MixedData_100000-4   	      40	  26792213 ns/op	10644751 B/op	  100004 allocs/op
PASS
ok  	github.com/ianlopshire/go-fixedwidth	3.096s
alex@penguin ~/p/go-fixedwidth> go test -bench=BenchmarkUnmarshal_MixedData_100000 
goos: linux
goarch: amd64
pkg: github.com/ianlopshire/go-fixedwidth
BenchmarkUnmarshal_MixedData_100000-4   	      36	  30539496 ns/op	11302631 B/op	  100005 allocs/op
PASS
ok  	github.com/ianlopshire/go-fixedwidth	2.083s
alex@penguin ~/p/go-fixedwidth> go test -bench=BenchmarkUnmarshal_MixedData_100000 
goos: linux
goarch: amd64
pkg: github.com/ianlopshire/go-fixedwidth
BenchmarkUnmarshal_MixedData_100000-4   	      37	  29794131 ns/op	11124792 B/op	  100005 allocs/op
PASS
ok  	github.com/ianlopshire/go-fixedwidth	1.960s
```