### PR TITLE
WithRightAlignedZeroPaddedNumbers and WithOverflowErrors Options

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -152,6 +152,32 @@ func TestNewValueEncoder(t *testing.T) {
 	}
 }
 
+func TestEncoderWithOverflowErrors(t *testing.T) {
+	buff := new(bytes.Buffer)
+	enc := NewEncoder(buff, WithOverflowErrors())
+
+	type obj struct {
+		ID string `fixed:"1,5"`
+	}
+
+	err := enc.Encode(&obj{ID: "toolong"})
+	if err == nil {
+		t.Errorf("expected an overflow error")
+	} else {
+		const expected = "Value 'toolong' of field ID is too long; 7 length where field is only 5 wide"
+		if err.Error() != expected {
+			t.Errorf("expected err %v, got %v", expected, err.Error())
+		}
+	}
+
+	buff2 := new(bytes.Buffer)
+	enc2 := NewEncoder(buff2)
+	err2 := enc2.Encode(&obj{ID: "toolong"})
+	if err2 != nil {
+		t.Errorf("expected no overflow error since we didn't enable that option; got %v", err2)
+	}
+}
+
 func TestEncoder_SetLineTerminator(t *testing.T) {
 	buff := new(bytes.Buffer)
 	enc := NewEncoder(buff)

--- a/encode_test.go
+++ b/encode_test.go
@@ -16,7 +16,7 @@ func ExampleMarshal() {
 		ID        int     `fixed:"1,5"`
 		FirstName string  `fixed:"6,15"`
 		LastName  string  `fixed:"16,25"`
-		Grade     float64 `fixed:"26,30"`
+		Grade     float64 `fixed:"26,31"`
 	}{
 		{1, "Ian", "Lopshire", 99.5},
 	}
@@ -28,6 +28,28 @@ func ExampleMarshal() {
 	fmt.Printf("%s", data)
 	// Output:
 	// 1    Ian       Lopshire  99.50
+}
+
+func ExampleEncoderWithOptions() {
+	buff := new(bytes.Buffer)
+	enc := NewEncoder(buff, WithRightAlignedZeroPaddedNumbers())
+
+	people := []struct {
+		ID        int     `fixed:"1,5"`
+		FirstName string  `fixed:"6,15"`
+		LastName  string  `fixed:"16,25"`
+		Grade     float64 `fixed:"26,31"`
+	}{
+		{1, "Ian", "Lopshire", 99.5},
+	}
+
+	err := enc.Encode(people)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s", buff.Bytes())
+	// Output:
+	// 00001Ian       Lopshire  099.50
 }
 
 func TestMarshal(t *testing.T) {
@@ -71,6 +93,8 @@ func TestMarshal(t *testing.T) {
 }
 
 func TestNewValueEncoder(t *testing.T) {
+	buff := new(bytes.Buffer)
+	enc := NewEncoder(buff)
 	for _, tt := range []struct {
 		name      string
 		i         interface{}
@@ -117,7 +141,7 @@ func TestNewValueEncoder(t *testing.T) {
 		{"TextUnmarshaler error", EncodableString{"foo", errors.New("TextUnmarshaler error")}, []byte("foo"), true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			o, err := newValueEncoder(reflect.TypeOf(tt.i))(reflect.ValueOf(tt.i))
+			o, err := newValueEncoder(reflect.TypeOf(tt.i))(reflect.ValueOf(tt.i), enc)
 			if tt.shouldErr != (err != nil) {
 				t.Errorf("newValueEncoder(%s)() shouldErr expected %v, have %v (%v)", reflect.TypeOf(tt.i).Name(), tt.shouldErr, err != nil, err)
 			}

--- a/tags.go
+++ b/tags.go
@@ -36,10 +36,18 @@ type structSpec struct {
 }
 
 type fieldSpec struct {
+	name             string
 	startPos, endPos int
 	encoder          valueEncoder
 	setter           valueSetter
 	ok               bool
+	isNumeric        bool
+	format           *fieldFormat
+}
+
+type fieldFormat struct {
+	rightAlign bool
+	padChar    byte
 }
 
 func buildStructSpec(t reflect.Type) structSpec {
@@ -54,6 +62,12 @@ func buildStructSpec(t reflect.Type) structSpec {
 		}
 		ss.fieldSpecs[i].encoder = newValueEncoder(f.Type)
 		ss.fieldSpecs[i].setter = newValueSetter(f.Type)
+		ss.fieldSpecs[i].name = f.Name
+
+		switch f.Type.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Float32, reflect.Float64:
+			ss.fieldSpecs[i].isNumeric = true
+		}
 	}
 	return ss
 }


### PR DESCRIPTION
This is partly solving #28, but in a less flexible way than the field/tag-level approach.  (Though also less prone to field-level mistakes since it'll consistently marshal ints without field-level configuration).

I add an `opts ...EncoderOption` variadic to the `NewEncoder` func, and add a `WithRightAlignedZeroPaddedInts()` option to enable a change in encoding behavior: right-aligned and zero-padded integers.