### PR TITLE
Add multibyte character support to encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ if err != nil {
 fmt.Printf("%s", data)
 // Output:
 // 1    Ian       Lopshire  99.5020 true
-
 ```
 
 ### Decode
@@ -95,13 +94,23 @@ for {
 }
 ```
 
-If you have an input where the indices are expressed in unicode codepoints, and
-not raw bytes fixedwidth supports this. Your data must be UTF-8 encoded:
+### UTF-8, Codepoints, and Multibyte Characters
+
+fixedwidth supports encoding and decoding fixed-width data where indices are expressed in
+unicode codepoints and not raw bytes. The data must be UTF-8 encoded.
 
 ```go
 decoder := fixedwidth.NewDecoder(strings.NewReader(data))
 decoder.SetUseCodepointIndices(true)
 // Decode as usual now
+```
+
+
+```go
+buff := new(bytes.Buffer)
+encoder := fixedwidth.NewEncoder(buff)
+encoder.SetUseCodepointIndices(true)
+// Encode as usual now
 ```
 
 ### Alignment Behavior

--- a/buff.go
+++ b/buff.go
@@ -1,0 +1,255 @@
+package fixedwidth
+
+import (
+	"bytes"
+	"errors"
+	"unicode/utf8"
+)
+
+// lineBuilder is a multibyte character aware buffer that can be used to efficiently build
+// a line of fixed width text.
+type lineBuilder struct {
+	data []byte
+
+	// Used when `SetUseCodepointIndices` has been called on `Encoder`. A
+	// mapping of codepoint indices into the bytes. So the `codepointIndices[n]` is the
+	// starting position for the n-th codepoint in `bytes`.
+	codepointIndices []int
+}
+
+// newLineBuilder makes a new lineBuilder. The line is filled with the provided fillChar.
+func newLineBuilder(len, cap int, fillChar byte) *lineBuilder {
+	data := make([]byte, len, cap)
+
+	// Fill the buffer with the fill character.
+	data[0] = fillChar
+	filled := 1
+	for filled < len {
+		copy(data[filled:], data[:filled])
+		filled *= 2
+	}
+
+	buff := &lineBuilder{
+		data: data,
+	}
+
+	return buff
+}
+
+// lineBufferFromValue creates a lineBuilder from a rawValue.
+func lineBufferFromValue(value rawValue) *lineBuilder {
+	buff := newLineBuilder(value.len(), value.byteLen(), ' ')
+	buff.WriteValue(0, value)
+	return buff
+}
+
+// WriteValue writes the given value to the lineBuilder at the give start index.
+func (b *lineBuilder) WriteValue(start int, value rawValue) {
+	// Fast path for ascii only operation.
+	if !b.hasMultiByteChar() && !value.hasMultiByteChar() {
+		copy(b.data[start:], value.data)
+		return
+	}
+
+	// If this is the first time a multibyte character has been encountered, the codepoint
+	// indices need to be initialized.
+	if !b.hasMultiByteChar() && value.hasMultiByteChar() {
+		b.initializeIndices()
+	}
+
+	end := start + value.len() - 1
+
+	// Calculate the byte start and end indices accounting for any multibyte characters.
+	byteStart := b.codepointIndices[start]
+	byteEnd := b.byteEndIndex(end)
+
+	writeSpan := b.data[byteStart : byteEnd+1]
+
+	// Ensure the there is space for the value being written. adjustByteSpan will grow or
+	// shrink the byte span if required.
+	byteDiff := value.byteLen() - len(writeSpan)
+	if byteDiff != 0 {
+		b.adjustByteSpan(end, byteDiff)
+
+		// Correct the writeSpan after the adjustment.
+		byteEnd = b.byteEndIndex(end)
+		writeSpan = b.data[byteStart : byteEnd+1]
+	}
+
+	// Write the value to the buffer
+	copy(b.data[byteStart:byteEnd+1], value.data)
+
+	// Correct the indices for the value that was just written. This only needs to happen
+	// if we adjusted the write-span or the new value contains multibyte characters.
+	if byteDiff != 0 || value.hasMultiByteChar() {
+		b.correctIndices(start, value)
+	}
+}
+
+// WriteASCII writes an ascii string to the line builder.
+func (b *lineBuilder) WriteASCII(start int, data string) {
+	v, _ := newRawValue(data, false)
+	b.WriteValue(start, v)
+}
+
+func (b *lineBuilder) String() string {
+	return string(b.data)
+}
+
+func (b *lineBuilder) AsRawValue() rawValue {
+	return rawValue{
+		data:             b.String(),
+		codepointIndices: b.codepointIndices,
+	}
+}
+
+func (b *lineBuilder) initializeIndices() {
+	b.codepointIndices = make([]int, len(b.data))
+	for i := range b.codepointIndices {
+		b.codepointIndices[i] = i
+	}
+}
+
+func (b *lineBuilder) correctIndices(start int, value rawValue) {
+	firstIndex := b.byteEndIndex(start-1) + 1
+
+	// Fast path for ascii values – there is no need to individually calculate the
+	// indices.
+	if !value.hasMultiByteChar() {
+		for i := 0; i < value.len(); i++ {
+			b.codepointIndices[start+i] = firstIndex + i
+		}
+		return
+	}
+
+	for i, s := range value.codepointIndices {
+		b.codepointIndices[start+i] = firstIndex + s
+	}
+}
+
+func (b *lineBuilder) adjustByteSpan(end, diff int) {
+	byteEnd := b.byteEndIndex(end)
+
+	switch {
+	case diff < 0:
+		// shorten buffer data
+		copy(b.data[byteEnd+diff:], b.data[byteEnd:])
+		b.data = b.data[:len(b.data)+diff]
+
+	case diff > 0:
+		// expand buffer data
+		b.data = append(b.data, bytes.Repeat([]byte{' '}, diff)...)
+		copy(b.data[byteEnd+diff:], b.data[byteEnd:])
+
+	}
+
+	// correct indices
+	for i := end + 1; i < len(b.codepointIndices); i++ {
+		b.codepointIndices[i] += diff
+	}
+}
+
+func (b *lineBuilder) byteStartIndex(start int) int {
+	if b.codepointIndices == nil {
+		return start
+	}
+	return b.codepointIndices[start]
+}
+
+func (b *lineBuilder) byteEndIndex(end int) int {
+	if b.codepointIndices == nil {
+		return end
+	}
+	if end == len(b.codepointIndices)-1 {
+		return len(b.data) - 1
+	}
+	return b.codepointIndices[end+1] - 1
+}
+
+func (b *lineBuilder) hasMultiByteChar() bool {
+	return b.codepointIndices != nil
+}
+
+type rawValue struct {
+	data string
+	// Used when `SetUseCodepointIndices` has been called on `Decoder` or `Encoder`. A
+	// mapping of codepoint indices into the bytes. So the `codepointIndices[n]` is the
+	// starting position for the n-th codepoint in `bytes`.
+	codepointIndices []int
+}
+
+func newRawValue(data string, useCodepointIndices bool) (rawValue, error) {
+	value := rawValue{
+		data: data,
+	}
+	if useCodepointIndices {
+		bytesIdx := findFirstMultiByteChar(data)
+		// If we've got multi-byte characters, fill in the rest of codepointIndices.
+		if bytesIdx < len(data) {
+			codepointIndices := make([]int, bytesIdx)
+			for i := 0; i < bytesIdx; i++ {
+				codepointIndices[i] = i
+			}
+			for bytesIdx < len(data) {
+				_, codepointSize := utf8.DecodeRuneInString(data[bytesIdx:])
+				if codepointSize == 0 {
+					return rawValue{}, errors.New("fixedwidth: Invalid codepoint")
+				}
+				codepointIndices = append(codepointIndices, bytesIdx)
+				bytesIdx += codepointSize
+			}
+			value.codepointIndices = codepointIndices
+		}
+	}
+	return value, nil
+}
+
+func (v rawValue) len() int {
+	if v.codepointIndices == nil {
+		return len(v.data)
+	}
+	return len(v.codepointIndices)
+}
+
+func (v rawValue) byteLen() int {
+	return len(v.data)
+}
+
+func (v rawValue) hasMultiByteChar() bool {
+	return v.codepointIndices != nil
+}
+
+func (v rawValue) byteStartIndex(start int) int {
+	if v.codepointIndices == nil {
+		return start
+	}
+	return v.codepointIndices[start]
+}
+
+func (v rawValue) byteEndIndex(end int) int {
+	if v.codepointIndices == nil {
+		return end
+	}
+	if end == len(v.codepointIndices)-1 {
+		return len(v.data) - 1
+	}
+	return v.codepointIndices[end+1] - 1
+}
+
+func (v rawValue) slice(start, end int) (rawValue, error) {
+	d := v.data[v.byteStartIndex(start) : v.byteEndIndex(end)+1]
+	return newRawValue(d, v.hasMultiByteChar())
+}
+
+// Scans bytes, looking for multi-byte characters, returns either the index of
+// the first multi-byte chracter or the length of the string if there are none.
+func findFirstMultiByteChar(data string) int {
+	for i := 0; i < len(data); i++ {
+		// We have a multi-byte codepoint, we need to allocate
+		// codepointIndices
+		if data[i]&0x80 == 0x80 {
+			return i
+		}
+	}
+	return len(data)
+}

--- a/buff_test.go
+++ b/buff_test.go
@@ -1,0 +1,347 @@
+package fixedwidth
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestMakeLineBuffer(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		len      int
+		cap      int
+		fillChar byte
+
+		expectData []byte
+	}{
+		{
+			name:       "base case",
+			len:        5,
+			cap:        10,
+			fillChar:   ' ',
+			expectData: []byte(`     `),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			buff := newLineBuilder(tt.len, tt.cap, tt.fillChar)
+
+			if len(buff.data) != tt.len {
+				t.Errorf("newLineBuilder() expected len %v, have %v", tt.len, len(buff.data))
+			}
+			if cap(buff.data) != tt.cap {
+				t.Errorf("newLineBuilder() expected cap %v, have %v", tt.cap, cap(buff.data))
+			}
+			if !bytes.Equal(buff.data, tt.expectData) {
+				t.Errorf("newLineBuilder() expected data %q, have %q", string(tt.expectData), string(buff.data))
+			}
+		})
+	}
+}
+
+func TestLineBuffer_writeValue(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+
+		buff *lineBuilder
+
+		start int
+		value string
+
+		expectData    []byte
+		expectIndices []int
+	}{
+		{
+			name:          "ascii to empty buff (fill)",
+			buff:          newLineBuilder(3, 3, ' '),
+			start:         0,
+			value:         "foo",
+			expectData:    []byte(`foo`),
+			expectIndices: nil,
+		},
+		{
+			name:          "ascii to empty buff (start)",
+			buff:          newLineBuilder(5, 5, ' '),
+			start:         0,
+			value:         "foo",
+			expectData:    []byte(`foo  `),
+			expectIndices: nil,
+		},
+		{
+			name:          "ascii to empty buff (end)",
+			buff:          newLineBuilder(5, 5, ' '),
+			start:         2,
+			value:         "foo",
+			expectData:    []byte(`  foo`),
+			expectIndices: nil,
+		},
+		{
+			name:          "ascii to empty buff (mid)",
+			buff:          newLineBuilder(5, 5, ' '),
+			start:         1,
+			value:         "foo",
+			expectData:    []byte(` foo `),
+			expectIndices: nil,
+		},
+		{
+			name:          "multibyte to empty buff (fill)",
+			buff:          newLineBuilder(3, 5, ' '),
+			start:         0,
+			value:         "føø",
+			expectData:    []byte(`føø`),
+			expectIndices: []int{0, 1, 3},
+		},
+		{
+			name:          "multibyte to empty buff (fill)(past cap)",
+			buff:          newLineBuilder(3, 3, ' '),
+			start:         0,
+			value:         "føø",
+			expectData:    []byte(`føø`),
+			expectIndices: []int{0, 1, 3},
+		},
+		{
+			name:          "multibyte to empty buff (start)",
+			buff:          newLineBuilder(5, 10, ' '),
+			start:         0,
+			value:         "føø",
+			expectData:    []byte(`føø  `),
+			expectIndices: []int{0, 1, 3, 5, 6},
+		},
+		{
+			name:          "multibyte to empty buff (end)",
+			buff:          newLineBuilder(5, 10, ' '),
+			start:         2,
+			value:         "føø",
+			expectData:    []byte(`  føø`),
+			expectIndices: []int{0, 1, 2, 3, 5},
+		},
+		{
+			name:          "multibyte to empty buff (mid)",
+			buff:          newLineBuilder(5, 10, ' '),
+			start:         1,
+			value:         "føø",
+			expectData:    []byte(` føø `),
+			expectIndices: []int{0, 1, 2, 4, 6},
+		},
+		{
+			name:          "multibyte to multibyte (fill)",
+			buff:          lineBufferFromValue(mustRawValue("ååå")),
+			start:         0,
+			value:         "øøø",
+			expectData:    []byte(`øøø`),
+			expectIndices: []int{0, 2, 4},
+		},
+		{
+			name:          "multibyte to multibyte (mid)",
+			buff:          lineBufferFromValue(mustRawValue("ååå")),
+			start:         1,
+			value:         "ø",
+			expectData:    []byte(`åøå`),
+			expectIndices: []int{0, 2, 4},
+		},
+		{
+			name:          "multibyte to multibyte (start)",
+			buff:          lineBufferFromValue(mustRawValue("ååå")),
+			start:         0,
+			value:         "ø",
+			expectData:    []byte(`øåå`),
+			expectIndices: []int{0, 2, 4},
+		},
+		{
+			name:          "multibyte to multibyte (end)",
+			buff:          lineBufferFromValue(mustRawValue("ååå")),
+			start:         2,
+			value:         "ø",
+			expectData:    []byte(`ååø`),
+			expectIndices: []int{0, 2, 4},
+		},
+		{
+			name:          "mixed to multibyte (fill)",
+			buff:          lineBufferFromValue(mustRawValue("ååå")),
+			start:         0,
+			value:         "føø",
+			expectData:    []byte(`føø`),
+			expectIndices: []int{0, 1, 3},
+		},
+		{
+			name:          "mixed to multibyte (fill)",
+			buff:          lineBufferFromValue(mustRawValue("ååå")),
+			start:         0,
+			value:         "øøf",
+			expectData:    []byte(`øøf`),
+			expectIndices: []int{0, 2, 4},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.buff.WriteValue(tt.start, mustRawValue(tt.value))
+			if !bytes.Equal(tt.buff.data, tt.expectData) {
+				t.Errorf("WriteValue() expected data %q, have %q", string(tt.expectData), string(tt.buff.data))
+				t.Errorf("WriteValue() expected data %v, have %v", tt.expectData, tt.buff.data)
+			}
+			if !reflect.DeepEqual(tt.buff.codepointIndices, tt.expectIndices) {
+				t.Errorf("WriteValue() expected indices %v, have %v", tt.expectIndices, tt.buff.codepointIndices)
+			}
+		})
+	}
+
+}
+
+func TestLineBuffer_byteEndIndex(t *testing.T) {
+	foo := &lineBuilder{
+		data:             []byte(`foo`),
+		codepointIndices: []int{0, 1, 2},
+	}
+	føø := &lineBuilder{
+		data:             []byte(`føø`),
+		codepointIndices: []int{0, 1, 3},
+	}
+
+	for _, tt := range []struct {
+		name        string
+		buff        *lineBuilder
+		end         int
+		expectIndex int
+	}{
+		{"foo[0]", foo, 0, 0},
+		{"foo[1]", foo, 1, 1},
+		{"foo[2]", foo, 2, 2},
+		{"føø[0]", føø, 0, 0},
+		{"føø[1]", føø, 1, 2},
+		{"føø[2]", føø, 2, 4},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			index := tt.buff.byteEndIndex(tt.end)
+			if index != tt.expectIndex {
+				t.Errorf("byteEndIndex() expected %v, have %v", tt.expectIndex, index)
+			}
+		})
+	}
+}
+
+func TestLineBuffer_byteStartIndex(t *testing.T) {
+	foo := &lineBuilder{
+		data:             []byte(`foo`),
+		codepointIndices: []int{0, 1, 2},
+	}
+	føø := &lineBuilder{
+		data:             []byte(`føø`),
+		codepointIndices: []int{0, 1, 3},
+	}
+
+	for _, tt := range []struct {
+		name        string
+		buff        *lineBuilder
+		start       int
+		expectIndex int
+	}{
+		{"foo[0]", foo, 0, 0},
+		{"foo[1]", foo, 1, 1},
+		{"foo[2]", foo, 2, 2},
+		{"føø[0]", føø, 0, 0},
+		{"føø[1]", føø, 1, 1},
+		{"føø[2]", føø, 2, 3},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			index := tt.buff.byteStartIndex(tt.start)
+			if index != tt.expectIndex {
+				t.Errorf("byteStartIndex() expected %v, have %v", tt.expectIndex, index)
+			}
+		})
+	}
+}
+
+func TestLineBuffer_adjustByteSpan(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+
+		buff *lineBuilder
+		end  int
+		diff int
+
+		expectData    []byte
+		expectIndices []int
+	}{
+		{
+			name: "shorten byte span (end)",
+			buff: &lineBuilder{
+				data:             []byte(`føø`),
+				codepointIndices: []int{0, 1, 3},
+			},
+			end:           2,
+			diff:          -1,
+			expectData:    append([]byte(`fø`), '\xb8'),
+			expectIndices: []int{0, 1, 3},
+		},
+		{
+			name: "shorten byte span (mid)",
+			buff: &lineBuilder{
+				data:             []byte(`føø`),
+				codepointIndices: []int{0, 1, 3},
+			},
+			end:           1,
+			diff:          -1,
+			expectData:    append([]byte{'f', '\xb8'}, "ø"...),
+			expectIndices: []int{0, 1, 2},
+		},
+		{
+			name: "expand byte span (end)",
+			buff: &lineBuilder{
+				data:             []byte(`føø`),
+				codepointIndices: []int{0, 1, 3},
+			},
+			end:           2,
+			diff:          1,
+			expectData:    append([]byte(`føø`), '\xb8'),
+			expectIndices: []int{0, 1, 3},
+		},
+
+		{
+			name: "expand byte span (mid)",
+			buff: &lineBuilder{
+				data:             []byte(`foø`),
+				codepointIndices: []int{0, 1, 2},
+			},
+			end:           1,
+			diff:          1,
+			expectData:    []byte("fooø"),
+			expectIndices: []int{0, 1, 3},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.buff.adjustByteSpan(tt.end, tt.diff)
+			if !bytes.Equal(tt.buff.data, tt.expectData) {
+				t.Errorf("adjustByteSpan() expected date %q, have %q", string(tt.expectData), string(tt.buff.data))
+				t.Errorf("adjustByteSpan() expected date %v, have %v", tt.expectData, tt.buff.data)
+			}
+			if !reflect.DeepEqual(tt.buff.codepointIndices, tt.expectIndices) {
+				t.Errorf("adjustByteSpan() expected indices %v, have %v", tt.expectIndices, tt.buff.codepointIndices)
+			}
+		})
+	}
+}
+
+func TestRawValue_len(t *testing.T) {
+	for _, tt := range []struct {
+		value rawValue
+		want  int
+	}{
+		{mustRawValue(""), 0},
+		{mustRawValue("foo"), 3},
+		{mustRawValue("føø"), 3},
+	} {
+		t.Run(tt.value.data, func(t *testing.T) {
+			if l := tt.value.len(); l != tt.want {
+				t.Errorf("len() expected %v, have %v", tt.want, l)
+
+			}
+		})
+	}
+}
+
+func mustRawValue(data string) rawValue {
+	v, err := newRawValue(data, true)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}

--- a/encode.go
+++ b/encode.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"reflect"
 	"strconv"
+	"strings"
 )
 
 // Marshal returns the fixed-width encoding of v.
@@ -60,6 +61,8 @@ func (e *MarshalInvalidTypeError) Error() string {
 type Encoder struct {
 	w              *bufio.Writer
 	lineTerminator []byte
+
+	useCodepointIndices bool
 }
 
 // NewEncoder returns a new encoder that writes to w.
@@ -75,6 +78,13 @@ func NewEncoder(w io.Writer) *Encoder {
 // The default value is "\n".
 func (e *Encoder) SetLineTerminator(lineTerminator []byte) {
 	e.lineTerminator = lineTerminator
+}
+
+// SetUseCodepointIndices configures `Encoder` on whether the indices in the
+// `fixedwidth` struct tags are expressed in terms of bytes (the default
+// behavior) or in terms of UTF-8 decoded codepoints.
+func (e *Encoder) SetUseCodepointIndices(use bool) {
+	e.useCodepointIndices = use
 }
 
 // Encode writes the fixed-width encoding of v to the
@@ -122,31 +132,31 @@ func (e *Encoder) writeLines(v reflect.Value) error {
 }
 
 func (e *Encoder) writeLine(v reflect.Value) (err error) {
-	b, err := newValueEncoder(v.Type())(v)
+	b, err := newValueEncoder(v.Type(), e.useCodepointIndices)(v)
 	if err != nil {
 		return err
 	}
-	_, err = e.w.Write(b)
+	_, err = e.w.WriteString(b.data)
 	return err
 }
 
-type valueEncoder func(v reflect.Value) ([]byte, error)
+type valueEncoder func(v reflect.Value) (rawValue, error)
 
-func newValueEncoder(t reflect.Type) valueEncoder {
+func newValueEncoder(t reflect.Type, useCodepointIndices bool) valueEncoder {
 	if t == nil {
 		return nilEncoder
 	}
 	if t.Implements(reflect.TypeOf(new(encoding.TextMarshaler)).Elem()) {
-		return textMarshalerEncoder
+		return textMarshalerEncoder(useCodepointIndices)
 	}
 
 	switch t.Kind() {
 	case reflect.Ptr, reflect.Interface:
-		return ptrInterfaceEncoder
+		return ptrInterfaceEncoder(useCodepointIndices)
 	case reflect.Struct:
-		return structEncoder
+		return structEncoder(useCodepointIndices)
 	case reflect.String:
-		return stringEncoder
+		return stringEncoder(useCodepointIndices)
 	case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8:
 		return intEncoder
 	case reflect.Float64:
@@ -161,18 +171,20 @@ func newValueEncoder(t reflect.Type) valueEncoder {
 	return unknownTypeEncoder(t)
 }
 
-func (ve valueEncoder) Write(v reflect.Value, dst []byte, format format) error {
+func (ve valueEncoder) Write(b *lineBuilder, v reflect.Value, spec fieldSpec) error {
+	format := spec.format
+	startIndex := spec.startPos - 1
 	value, err := ve(v)
 	if err != nil {
 		return err
 	}
 
-	if len(value) < len(dst) {
+	if value.len() < spec.len() {
 		switch {
-		case format.alignment == right:
-			padding := bytes.Repeat([]byte{format.padChar}, len(dst)-len(value))
-			copy(dst, padding)
-			copy(dst[len(padding):], value)
+		case spec.format.alignment == right:
+			padding := strings.Repeat(string(format.padChar), spec.len()-value.len())
+			b.WriteASCII(startIndex, padding)
+			b.WriteValue(startIndex+len(padding), value)
 			return nil
 
 		// The second case in this block is a special case to maintain backward
@@ -180,74 +192,102 @@ func (ve valueEncoder) Write(v reflect.Value, dst []byte, format format) error {
 		// written to dst. This means overlapping intervals can, in effect, be used to
 		// coalesce a value.
 		case format.alignment == left, format.alignment == defaultAlignment && format.padChar != ' ':
-			padding := bytes.Repeat([]byte{format.padChar}, len(dst)-len(value))
-			copy(dst, value)
-			copy(dst[len(value):], padding)
+			padding := strings.Repeat(string(format.padChar), spec.len()-value.len())
+
+			b.WriteValue(startIndex, value)
+			b.WriteASCII(startIndex+value.len(), padding)
 			return nil
 		}
 	}
 
-	copy(dst, value)
+	if value.len() > spec.len() {
+		// If the value is too long it needs to be trimmed.
+		// TODO: Add strict mode that returns in this case.
+		value, err = value.slice(0, spec.len()-1)
+		if err != nil {
+			return err
+		}
+	}
+
+	b.WriteValue(startIndex, value)
 	return nil
 }
 
-func structEncoder(v reflect.Value) ([]byte, error) {
-	ss := cachedStructSpec(v.Type())
-	dst := bytes.Repeat([]byte(" "), ss.ll)
+func structEncoder(useCodepointIndices bool) valueEncoder {
+	return func(v reflect.Value) (rawValue, error) {
+		ss := cachedStructSpec(v.Type())
 
-	for i, spec := range ss.fieldSpecs {
-		if !spec.ok {
-			continue
+		// Add a 10% headroom to the builder when codepoint indices are being used.
+		c := ss.ll
+		if useCodepointIndices {
+			c = int(1.1*float64(ss.ll)) + 1
+		}
+		b := newLineBuilder(ss.ll, c, ' ')
+
+		for i, spec := range ss.fieldSpecs {
+			if !spec.ok {
+				continue
+			}
+
+			enc := spec.getEncoder(useCodepointIndices)
+			err := enc.Write(b, v.Field(i), spec)
+			if err != nil {
+				return rawValue{}, err
+			}
 		}
 
-		err := spec.encoder.Write(v.Field(i), dst[spec.startPos-1:spec.endPos:spec.endPos], spec.format)
+		return b.AsRawValue(), nil
+	}
+}
+
+func textMarshalerEncoder(useCodepointIndices bool) valueEncoder {
+	return func(v reflect.Value) (rawValue, error) {
+		txt, err := v.Interface().(encoding.TextMarshaler).MarshalText()
 		if err != nil {
-			return nil, err
+			return rawValue{}, err
 		}
+		return newRawValue(string(txt), useCodepointIndices)
 	}
-
-	return dst, nil
 }
 
-func textMarshalerEncoder(v reflect.Value) ([]byte, error) {
-	return v.Interface().(encoding.TextMarshaler).MarshalText()
-}
-
-func ptrInterfaceEncoder(v reflect.Value) ([]byte, error) {
-	if v.IsNil() {
-		return nilEncoder(v)
+func ptrInterfaceEncoder(useCodepointIndices bool) valueEncoder {
+	return func(v reflect.Value) (rawValue, error) {
+		if v.IsNil() {
+			return nilEncoder(v)
+		}
+		return newValueEncoder(v.Elem().Type(), useCodepointIndices)(v.Elem())
 	}
-	return newValueEncoder(v.Elem().Type())(v.Elem())
 }
 
-func stringEncoder(v reflect.Value) ([]byte, error) {
-	return []byte(v.String()), nil
+func stringEncoder(useCodepointIndices bool) valueEncoder {
+	return func(v reflect.Value) (rawValue, error) {
+		return newRawValue(v.String(), useCodepointIndices)
+	}
 }
-
-func intEncoder(v reflect.Value) ([]byte, error) {
-	return []byte(strconv.Itoa(int(v.Int()))), nil
+func intEncoder(v reflect.Value) (rawValue, error) {
+	return newRawValue(strconv.Itoa(int(v.Int())), false)
 }
 
 func floatEncoder(perc, bitSize int) valueEncoder {
-	return func(v reflect.Value) ([]byte, error) {
-		return []byte(strconv.FormatFloat(v.Float(), 'f', perc, bitSize)), nil
+	return func(v reflect.Value) (rawValue, error) {
+		return newRawValue(strconv.FormatFloat(v.Float(), 'f', perc, bitSize), false)
 	}
 }
 
-func boolEncoder(v reflect.Value) ([]byte, error) {
-	return []byte(strconv.FormatBool(v.Bool())), nil
+func boolEncoder(v reflect.Value) (rawValue, error) {
+	return newRawValue(strconv.FormatBool(v.Bool()), false)
 }
 
-func nilEncoder(v reflect.Value) ([]byte, error) {
-	return nil, nil
+func nilEncoder(_ reflect.Value) (rawValue, error) {
+	return rawValue{}, nil
 }
 
 func unknownTypeEncoder(t reflect.Type) valueEncoder {
-	return func(value reflect.Value) ([]byte, error) {
-		return nil, &MarshalInvalidTypeError{typeName: t.Name()}
+	return func(value reflect.Value) (rawValue, error) {
+		return rawValue{}, &MarshalInvalidTypeError{typeName: t.Name()}
 	}
 }
 
-func uintEncoder(v reflect.Value) ([]byte, error) {
-	return []byte(strconv.FormatUint(v.Uint(), 10)), nil
+func uintEncoder(v reflect.Value) (rawValue, error) {
+	return newRawValue(strconv.FormatUint(v.Uint(), 10), false)
 }

--- a/tags.go
+++ b/tags.go
@@ -64,9 +64,21 @@ type structSpec struct {
 type fieldSpec struct {
 	startPos, endPos int
 	encoder          valueEncoder
+	codepointEncoder valueEncoder
 	setter           valueSetter
 	format           format
 	ok               bool
+}
+
+func (s fieldSpec) len() int {
+	return s.endPos - s.startPos + 1
+}
+
+func (s fieldSpec) getEncoder(useCodepointIndices bool) valueEncoder {
+	if useCodepointIndices {
+		return s.codepointEncoder
+	}
+	return s.encoder
 }
 
 func buildStructSpec(t reflect.Type) structSpec {
@@ -90,7 +102,8 @@ func buildStructSpec(t reflect.Type) structSpec {
 			ss.ll = ss.fieldSpecs[i].endPos
 		}
 
-		ss.fieldSpecs[i].encoder = newValueEncoder(f.Type)
+		ss.fieldSpecs[i].encoder = newValueEncoder(f.Type, false)
+		ss.fieldSpecs[i].codepointEncoder = newValueEncoder(f.Type, true)
 		ss.fieldSpecs[i].setter = newValueSetter(f.Type)
 	}
 	return ss

--- a/tags_test.go
+++ b/tags_test.go
@@ -1,6 +1,7 @@
 package fixedwidth
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -48,6 +49,25 @@ func TestParseTag(t *testing.T) {
 				if !reflect.DeepEqual(tt.format, format) {
 					t.Errorf("parseTagWithFormat() format want %+v, have %+v", tt.format, format)
 				}
+			}
+		})
+	}
+}
+
+func TestFieldSpec_len(t *testing.T) {
+	for _, tt := range []struct {
+		spec fieldSpec
+		want int
+	}{
+		{fieldSpec{startPos: 1, endPos: 1}, 1},
+		{fieldSpec{startPos: 1, endPos: 5}, 5},
+		{fieldSpec{startPos: 5, endPos: 5}, 1},
+		{fieldSpec{startPos: 6, endPos: 10}, 5},
+	} {
+		t.Run(fmt.Sprintf("%v to %v", tt.spec.startPos, tt.spec.endPos), func(t *testing.T) {
+			if l := tt.spec.len(); l != tt.want {
+				t.Errorf("len() expected %v, have %v", tt.want, l)
+
 			}
 		})
 	}


### PR DESCRIPTION
This PR adds multicharacter byte support to the encoder. 

Resolves #11 

### Benchmarks

```
name                                    old time/op    new time/op    delta
Marshal_MixedData_1-16                    2.76µs ± 3%    2.85µs ± 3%     ~     (p=0.222 n=5+5)
Marshal_MixedData_1000-16                 1.95ms ± 5%    2.15ms ± 5%  +10.58%  (p=0.008 n=5+5)
Marshal_MixedData_100000-16                193ms ± 8%     203ms ± 7%     ~     (p=0.151 n=5+5)
Marshal_String-16                          928ns ± 2%     978ns ± 3%   +5.35%  (p=0.016 n=5+5)
Marshal_StringPtr-16                       962ns ± 3%    1040ns ± 9%   +8.11%  (p=0.008 n=5+5)
Marshal_Int64-16                           920ns ± 1%     980ns ± 5%   +6.57%  (p=0.016 n=4+5)
Marshal_Float64-16                        1.16µs ± 2%    1.24µs ± 4%   +6.62%  (p=0.008 n=5+5)
Marshal_Bool-16                            952ns ± 8%     970ns ± 4%     ~     (p=0.421 n=5+5)

name                                    old alloc/op   new alloc/op   delta
Marshal_MixedData_1-16                    5.00kB ± 0%    5.06kB ± 0%   +1.12%  (p=0.008 n=5+5)
Marshal_MixedData_1000-16                 1.02MB ± 0%    1.08MB ± 0%   +5.88%  (p=0.016 n=4+5)
Marshal_MixedData_100000-16               84.7MB ± 0%    90.7MB ± 0%   +7.08%  (p=0.016 n=5+4)
Marshal_String-16                         4.34kB ± 0%    4.35kB ± 0%   +0.37%  (p=0.008 n=5+5)
Marshal_StringPtr-16                      4.34kB ± 0%    4.37kB ± 0%   +0.74%  (p=0.008 n=5+5)
Marshal_Int64-16                          4.32kB ± 0%    4.34kB ± 0%   +0.37%  (p=0.008 n=5+5)
Marshal_Float64-16                        4.34kB ± 0%    4.38kB ± 0%   +0.74%  (p=0.008 n=5+5)
Marshal_Bool-16                           4.32kB ± 0%    4.34kB ± 0%   +0.37%  (p=0.008 n=5+5)

name                                    old allocs/op  new allocs/op  delta
Marshal_MixedData_1-16                      36.0 ± 0%      24.0 ± 0%  -33.33%  (p=0.008 n=5+5)
Marshal_MixedData_1000-16                  30.0k ± 0%     18.0k ± 0%  -39.99%  (p=0.008 n=5+5)
Marshal_MixedData_100000-16                3.00M ± 0%     1.80M ± 0%  -40.00%  (p=0.016 n=5+4)
Marshal_String-16                           9.00 ± 0%     10.00 ± 0%  +11.11%  (p=0.008 n=5+5)
Marshal_StringPtr-16                        9.00 ± 0%     11.00 ± 0%  +22.22%  (p=0.008 n=5+5)
Marshal_Int64-16                            8.00 ± 0%      9.00 ± 0%  +12.50%  (p=0.008 n=5+5)
Marshal_Float64-16                          11.0 ± 0%      12.0 ± 0%   +9.09%  (p=0.008 n=5+5)
Marshal_Bool-16                             9.00 ± 0%     10.00 ± 0%  +11.11%  (p=0.008 n=5+5)
```