### PR TITLE
Encoder performance

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -145,6 +145,58 @@ func BenchmarkMarshal_MixedData_100000(b *testing.B) {
 	}
 }
 
+func BenchmarkEncode_CodePoints_MixedData_1_Ascii(b *testing.B) {
+	v := mixedData{
+		F1:  "foo",
+		F2:  stringp("foo"),
+		F3:  42,
+		F4:  int64p(42),
+		F5:  42,
+		F6:  int32p(42),
+		F7:  42,
+		F8:  int16p(42),
+		F9:  42,
+		F10: int8p(8),
+		F11: 42,
+		F12: float64p(42),
+		F13: 42,
+		F14: false,
+		F15: true,
+	}
+	for i := 0; i < b.N; i++ {
+		buff := new(bytes.Buffer)
+		d := NewEncoder(buff)
+		d.SetUseCodepointIndices(true)
+		_ = d.Encode(v)
+	}
+}
+
+func BenchmarkEncode_CodePoints_MixedData_1_UTF8(b *testing.B) {
+	v := mixedData{
+		F1:  "f☃☃",
+		F2:  stringp("f☃☃"),
+		F3:  42,
+		F4:  int64p(42),
+		F5:  42,
+		F6:  int32p(42),
+		F7:  42,
+		F8:  int16p(42),
+		F9:  42,
+		F10: int8p(8),
+		F11: 42,
+		F12: float64p(42),
+		F13: 42,
+		F14: false,
+		F15: true,
+	}
+	for i := 0; i < b.N; i++ {
+		buff := new(bytes.Buffer)
+		d := NewEncoder(buff)
+		d.SetUseCodepointIndices(true)
+		_ = d.Encode(v)
+	}
+}
+
 func BenchmarkMarshal_String(b *testing.B) {
 	v := struct {
 		F1 string `fixed:"1,10"`

--- a/encode_test.go
+++ b/encode_test.go
@@ -2,12 +2,11 @@ package fixedwidth
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"log"
 	"reflect"
 	"testing"
-
-	"github.com/pkg/errors"
 )
 
 func ExampleMarshal() {
@@ -147,7 +146,7 @@ func TestMarshal_useCodepointIndices(t *testing.T) {
 				return
 			}
 			if o := buff.Bytes(); !bytes.Equal(o, tt.o) {
-				t.Errorf("Marshal() expected %s, have %s", tt.o, o)
+				t.Errorf("Marshal() expected %q, have %q", string(tt.o), string(o))
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/ianlopshire/go-fixedwidth
 
 go 1.13
-
-require github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
### Benchmarks 

```
name                                    old time/op    new time/op    delta
Unmarshal_MixedData_1-10                  2.39µs ± 1%    2.40µs ± 0%     ~     (p=0.381 n=5+5)
Unmarshal_MixedData_1000-10               2.65µs ± 3%    2.64µs ± 3%     ~     (p=0.889 n=5+5)
Unmarshal_MixedData_100000-10             2.79µs ± 4%    2.77µs ± 4%     ~     (p=0.595 n=5+5)
Decode_CodePoints_MixedData_1_Ascii-10    2.47µs ± 3%    2.46µs ± 2%     ~     (p=1.000 n=5+5)
Decode_CodePoints_MixedData_1_UTF8-10     3.43µs ± 4%    3.40µs ± 2%     ~     (p=0.421 n=5+5)
Unmarshal_String-10                        762ns ± 2%     751ns ± 2%     ~     (p=0.095 n=5+5)
Unmarshal_StringPtr-10                     769ns ± 0%     763ns ± 2%     ~     (p=0.286 n=4+5)
Unmarshal_Int64-10                         765ns ± 1%     782ns ±12%     ~     (p=1.000 n=5+5)
Unmarshal_Float64-10                       787ns ± 1%     773ns ± 2%   -1.75%  (p=0.032 n=5+5)
Marshal_MixedData_1-10                    2.36µs ± 2%    2.33µs ± 1%   -1.07%  (p=0.032 n=5+5)
Marshal_MixedData_1000-10                 1.98ms ± 1%    1.92ms ± 0%   -3.06%  (p=0.008 n=5+5)
Marshal_MixedData_100000-10                194ms ± 0%     190ms ± 1%   -2.07%  (p=0.008 n=5+5)
Encode_CodePoints_MixedData_1_Ascii-10    2.20µs ± 2%    2.18µs ± 0%     ~     (p=0.087 n=5+5)
Encode_CodePoints_MixedData_1_UTF8-10     2.79µs ± 1%    2.78µs ± 1%     ~     (p=0.135 n=5+5)
Marshal_String-10                          609ns ± 2%     607ns ± 5%     ~     (p=0.690 n=5+5)
Marshal_StringPtr-10                       648ns ± 1%     648ns ± 1%     ~     (p=1.000 n=5+4)
Marshal_Int64-10                           592ns ± 1%     591ns ± 1%     ~     (p=0.937 n=5+5)
Marshal_Float64-10                         778ns ± 1%     770ns ± 2%     ~     (p=0.056 n=5+5)
Marshal_Bool-10                            608ns ± 6%     594ns ± 3%     ~     (p=0.310 n=5+5)

name                                    old alloc/op   new alloc/op   delta
Unmarshal_MixedData_1-10                  5.14kB ± 0%    5.14kB ± 0%     ~     (all equal)
Unmarshal_MixedData_1000-10               5.27kB ± 0%    5.27kB ± 0%     ~     (all equal)
Unmarshal_MixedData_100000-10             5.27kB ± 0%    5.27kB ± 0%     ~     (all equal)
Decode_CodePoints_MixedData_1_Ascii-10    5.14kB ± 0%    5.14kB ± 0%     ~     (all equal)
Decode_CodePoints_MixedData_1_UTF8-10     9.19kB ± 0%    9.19kB ± 0%     ~     (all equal)
Unmarshal_String-10                       4.49kB ± 0%    4.49kB ± 0%     ~     (all equal)
Unmarshal_StringPtr-10                    4.49kB ± 0%    4.49kB ± 0%     ~     (all equal)
Unmarshal_Int64-10                        4.49kB ± 0%    4.49kB ± 0%     ~     (all equal)
Unmarshal_Float64-10                      4.49kB ± 0%    4.49kB ± 0%     ~     (all equal)
Marshal_MixedData_1-10                    5.06kB ± 0%    5.06kB ± 0%     ~     (all equal)
Marshal_MixedData_1000-10                 1.08MB ± 0%    1.05MB ± 0%   -2.96%  (p=0.008 n=5+5)
Marshal_MixedData_100000-10               90.7MB ± 0%    87.5MB ± 0%   -3.53%  (p=0.016 n=4+5)
Encode_CodePoints_MixedData_1_Ascii-10    5.07kB ± 0%    5.07kB ± 0%     ~     (all equal)
Encode_CodePoints_MixedData_1_UTF8-10     6.48kB ± 0%    6.48kB ± 0%     ~     (all equal)
Marshal_String-10                         4.35kB ± 0%    4.35kB ± 0%     ~     (all equal)
Marshal_StringPtr-10                      4.37kB ± 0%    4.37kB ± 0%     ~     (all equal)
Marshal_Int64-10                          4.34kB ± 0%    4.34kB ± 0%     ~     (all equal)
Marshal_Float64-10                        4.38kB ± 0%    4.38kB ± 0%     ~     (all equal)
Marshal_Bool-10                           4.34kB ± 0%    4.34kB ± 0%     ~     (all equal)

name                                    old allocs/op  new allocs/op  delta
Unmarshal_MixedData_1-10                    40.0 ± 0%      40.0 ± 0%     ~     (all equal)
Unmarshal_MixedData_1000-10                 46.0 ± 0%      46.0 ± 0%     ~     (all equal)
Unmarshal_MixedData_100000-10               46.0 ± 0%      46.0 ± 0%     ~     (all equal)
Decode_CodePoints_MixedData_1_Ascii-10      40.0 ± 0%      40.0 ± 0%     ~     (all equal)
Decode_CodePoints_MixedData_1_UTF8-10       46.0 ± 0%      46.0 ± 0%     ~     (all equal)
Unmarshal_String-10                         11.0 ± 0%      11.0 ± 0%     ~     (all equal)
Unmarshal_StringPtr-10                      11.0 ± 0%      11.0 ± 0%     ~     (all equal)
Unmarshal_Int64-10                          11.0 ± 0%      11.0 ± 0%     ~     (all equal)
Unmarshal_Float64-10                        11.0 ± 0%      11.0 ± 0%     ~     (all equal)
Marshal_MixedData_1-10                      24.0 ± 0%      24.0 ± 0%     ~     (all equal)
Marshal_MixedData_1000-10                  18.0k ± 0%     16.0k ± 0%  -11.09%  (p=0.008 n=5+5)
Marshal_MixedData_100000-10                1.80M ± 0%     1.60M ± 0%  -11.11%  (p=0.016 n=4+5)
Encode_CodePoints_MixedData_1_Ascii-10      24.0 ± 0%      24.0 ± 0%     ~     (all equal)
Encode_CodePoints_MixedData_1_UTF8-10       33.0 ± 0%      33.0 ± 0%     ~     (all equal)
Marshal_String-10                           10.0 ± 0%      10.0 ± 0%     ~     (all equal)
Marshal_StringPtr-10                        11.0 ± 0%      11.0 ± 0%     ~     (all equal)
Marshal_Int64-10                            9.00 ± 0%      9.00 ± 0%     ~     (all equal)
Marshal_Float64-10                          12.0 ± 0%      12.0 ± 0%     ~     (all equal)
Marshal_Bool-10                             10.0 ± 0%      10.0 ± 0%     ~     (all equal)
```