### PR TITLE
Correct LF and CR labels

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -463,7 +463,7 @@ func TestLineSeparator(t *testing.T) {
 		lineTerminator []byte
 	}{
 		{
-			name:     "CR line endings",
+			name:     "LF line endings",
 			rawValue: []byte("foo  123  1.2  bar" + "\n" + "bar  321  2.1  foo"),
 			target:   &[]allTypes{},
 			expected: &[]allTypes{
@@ -474,7 +474,7 @@ func TestLineSeparator(t *testing.T) {
 			lineTerminator: []byte{},
 		},
 		{
-			name:     "CR line endings",
+			name:     "LF line endings",
 			rawValue: []byte("f\ro  123  1.2  bar" + "\n" + "bar  321  2.1  foo"),
 			target:   &[]allTypes{},
 			expected: &[]allTypes{
@@ -496,7 +496,7 @@ func TestLineSeparator(t *testing.T) {
 			lineTerminator: []byte("\r\n"),
 		},
 		{
-			name:     "LF line endings",
+			name:     "CR line endings",
 			rawValue: []byte("f\no  123  1.2  bar" + "\r" + "bar  321  2.1  foo"),
 			target:   &[]allTypes{},
 			expected: &[]allTypes{


### PR DESCRIPTION
Per https://go.dev/ref/spec#Rune_literals, "\n" is a line feed
character, while "\r" is a carriage return. This change updates test
names to match the right character tested.