### PR TITLE
Multi Byte Characters cause flat file definitions to shift 

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -239,7 +239,7 @@ func rawValueFromLine(value rawValue, startPos, endPos int, format format) rawVa
 			endPos = len(value.data)
 		}
 		return rawValue{
-			data: trimFunc(value.data[startPos-1 : endPos]),
+			data: trimFunc(string([]rune(value.data)[startPos-1 : endPos])),
 		}
 	}
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -113,6 +113,20 @@ func TestUnmarshal(t *testing.T) {
 			shouldErr: false,
 		},
 		{
+			name:      "Multi Byte Character Test - em dash",
+			rawValue:  []byte("f–o  123  1.2  bar  12345 false f"),
+			target:    &allTypes{},
+			expected:  &allTypes{"f–o", 123, 1.2, EncodableString{"bar", nil}, uint(12345), false, false},
+			shouldErr: false,
+		},
+		{
+			name:      "Multi Byte Character Test - Accent Char",
+			rawValue:  []byte("foé  123  1.2  bar  12345 false f"),
+			target:    &allTypes{},
+			expected:  &allTypes{"foé", 123, 1.2, EncodableString{"bar", nil}, uint(12345), false, false},
+			shouldErr: false,
+		},
+		{
 			name:      "Unmarshal Error",
 			rawValue:  []byte("foo  nan  ddd  bar  baz"),
 			target:    &allTypes{},


### PR DESCRIPTION
In current state, if you have a file that contain multi-byte characters (for example, em dash, accented characters, etc). The unmarshal moves the characters over x positions depending on the bytes. This causes some values from other fields to not be in the correct struct field.

This PR will change the string unmarshal to convert to a rune before picking the start and end positions and select full characters instead of bytes.