### PR TITLE
Return error in the error branch

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -184,7 +184,7 @@ func (d *Decoder) readLine(v reflect.Value) (err error, ok bool) {
 
 	rawValue, err := newRawValue(line, d.useCodepointIndices)
 	if err != nil {
-		return
+		return err, false
 	}
 	t := v.Type()
 	if t == d.lastType {


### PR DESCRIPTION
This change fixes the issue when there is an error in decoding, where the original code would return no error and false for ok. That would confuse the calling function.

Fixes #55 