### PR TITLE
Add go 1.20 to the matrix and update actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,11 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.15', '1.16', '1.17', '1.18', '1.19']
+        go: ['1.15', '1.16', '1.17', '1.18', '1.19', '1.20']
     steps:
       - uses: actions/checkout@master
       - name: Setup go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
       - name: go get & test


### PR DESCRIPTION
This change adds the latest go in the build matrix and updates the setup-go action.